### PR TITLE
[FLINK-XXXX] Add interfaces for SchedulingTopology

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingEdge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingEdge.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.strategy;
+
+import org.apache.flink.runtime.executiongraph.ExecutionEdge;
+
+/**
+ * Represents {@link ExecutionEdge}.
+ */
+public interface SchedulingEdge {
+
+	/**
+	 * Gets the producer of the results.
+	 *
+	 * @return Scheduling vertex representing the producer
+	 */
+	SchedulingVertex getProducer();
+
+	/**
+	 * Gets the consumer fo the results.
+	 *
+	 * @return Scheduling vertex representing the consumer
+	 */
+	SchedulingVertex getConsumer();
+
+	/**
+	 * Information about the produced/consumed result partition.
+	 *
+	 * @return SchedulingResultPartition
+	 */
+	SchedulingResultPartition getResultPartition();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingVertex.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.strategy;
+
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import java.util.Collection;
+
+/**
+ * Scheduling representation of {@link ExecutionVertex}.
+ */
+public interface SchedulingVertex {
+
+	/**
+	 * Gets id of the execution vertex.
+	 *
+	 * @return id of the execution vertex
+	 */
+	ExecutionVertexID getId();
+
+	/**
+	 * Gets the state of the execution vertex.
+	 *
+	 * @return state of the execution vertex
+	 */
+	ExecutionState getState();
+
+	/**
+	 * Gets the {@link JobVertexID} identifying the underlying job vertex
+	 * which this scheduling vertex represents.
+	 *
+	 * @return job vertex id representing the underlying operator
+	 */
+	JobVertexID getJobVertexId();
+
+	/**
+	 * Get all input edges. An input edge connects a producer with a consumer
+	 * and contains information about the result partition.
+	 *
+	 * @return collection of input edges
+	 */
+	Collection<SchedulingEdge> getInputs();
+
+	/**
+	 * Get all output edges. An output edge connects a producer with a consumer
+	 * and contains information about the result partition.
+	 *
+	 * @return collection of output edges
+	 */
+	Collection<SchedulingEdge> getOutputs();
+}


### PR DESCRIPTION
### **User description**
The SchedulingTopology contains the information which is provided to the SchedulingStrategy in order to decide which execution vertices should be scheduled next.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced `SchedulingEdge` interface to represent execution edges.

- Added `SchedulingVertex` interface for execution vertex representation.

- Defined methods for producers, consumers, and state retrieval in scheduling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SchedulingEdge.java</strong><dd><code>Introduced `SchedulingEdge` interface for execution edges</code></dd></summary>
<hr>

flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingEdge.java

<li>Added <code>SchedulingEdge</code> interface for execution edge representation.<br> <li> Defined methods to retrieve producer, consumer, and result partition.<br> <li> Included JavaDoc for all methods and the interface.


</details>


  </td>
  <td><a href="https://github.com/GuusArts/flink-guus/pull/6/files#diff-a0ad754d23a40dc09280da86327389288773ff85fe83566339daddbe670d6dc2">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SchedulingVertex.java</strong><dd><code>Added `SchedulingVertex` interface for execution vertices</code></dd></summary>
<hr>

flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingVertex.java

<li>Added <code>SchedulingVertex</code> interface for execution vertex representation.<br> <li> Defined methods for vertex ID, state, and job vertex ID retrieval.<br> <li> Included methods to fetch input and output edges.<br> <li> Documented all methods and the interface with JavaDoc.


</details>


  </td>
  <td><a href="https://github.com/GuusArts/flink-guus/pull/6/files#diff-5d5d8d7ebb7bf597429038f1053a328afcdd28e63dbb602cd434ebd4def4be3a">+69/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>