### PR TITLE
25218 before improvements v2

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/DefaultSlotAssigner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/DefaultSlotAssigner.java
@@ -18,23 +18,24 @@
 
 package org.apache.flink.runtime.scheduler.adaptive.allocator;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.scheduler.adaptive.JobSchedulingPlan.SlotAssignment;
 import org.apache.flink.runtime.scheduler.adaptive.allocator.SlotSharingSlotAllocator.ExecutionSlotSharingGroup;
-import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
+
+import static org.apache.flink.runtime.scheduler.adaptive.allocator.SlotAssigner.createExecutionSlotSharingGroups;
+import static org.apache.flink.runtime.scheduler.adaptive.allocator.SlotAssigner.getSlotsPerTaskExecutor;
+import static org.apache.flink.runtime.scheduler.adaptive.allocator.SlotAssigner.sortTaskExecutors;
 
 /** Simple {@link SlotAssigner} that treats all slots and slot sharing groups equally. */
 public class DefaultSlotAssigner implements SlotAssigner {
@@ -50,9 +51,16 @@ public class DefaultSlotAssigner implements SlotAssigner {
             allGroups.addAll(createExecutionSlotSharingGroups(vertexParallelism, slotSharingGroup));
         }
 
-        Iterator<? extends SlotInfo> iterator =
-                selectSlotsInMinimalTaskExecutors(freeSlots, allGroups, Collections.emptyList())
-                        .iterator();
+        final Map<TaskManagerLocation, ? extends Set<? extends SlotInfo>> slotsPerTaskExecutor =
+                getSlotsPerTaskExecutor(freeSlots);
+        final Collection<? extends SlotInfo> slotInfos =
+                selectSlotsInMinimalTaskExecutors(
+                        freeSlots,
+                        slotsPerTaskExecutor,
+                        allGroups.size(),
+                        getSortedTaskExecutors(slotsPerTaskExecutor));
+
+        Iterator<? extends SlotInfo> iterator = slotInfos.iterator();
         Collection<SlotAssignment> assignments = new ArrayList<>();
         for (ExecutionSlotSharingGroup group : allGroups) {
             assignments.add(new SlotAssignment(iterator.next(), group));
@@ -60,36 +68,11 @@ public class DefaultSlotAssigner implements SlotAssigner {
         return assignments;
     }
 
-    @Override
-    public List<TaskManagerLocation> sortPrioritizedTaskExecutors(
-            Collection<? extends SlotInfo> slots, Collection<AllocationScore> scores) {
-        Map<TaskManagerLocation, ? extends Set<? extends SlotInfo>> slotsByTaskExecutor =
-                SlotAssigner.getSlotsPerTaskExecutor(slots);
-        return slotsByTaskExecutor.keySet().stream()
-                .sorted(
-                        (left, right) ->
-                                Integer.compare(
-                                        slotsByTaskExecutor.get(right).size(),
-                                        slotsByTaskExecutor.get(left).size()))
-                .collect(Collectors.toList());
-    }
-
-    static List<ExecutionSlotSharingGroup> createExecutionSlotSharingGroups(
-            VertexParallelism vertexParallelism, SlotSharingGroup slotSharingGroup) {
-        final Map<Integer, Set<ExecutionVertexID>> sharedSlotToVertexAssignment = new HashMap<>();
-        slotSharingGroup
-                .getJobVertexIds()
-                .forEach(
-                        jobVertexId -> {
-                            int parallelism = vertexParallelism.getParallelism(jobVertexId);
-                            for (int subtaskIdx = 0; subtaskIdx < parallelism; subtaskIdx++) {
-                                sharedSlotToVertexAssignment
-                                        .computeIfAbsent(subtaskIdx, ignored -> new HashSet<>())
-                                        .add(new ExecutionVertexID(jobVertexId, subtaskIdx));
-                            }
-                        });
-        return sharedSlotToVertexAssignment.values().stream()
-                .map(ExecutionSlotSharingGroup::new)
-                .collect(Collectors.toList());
+    @VisibleForTesting
+    List<TaskManagerLocation> getSortedTaskExecutors(
+            Map<TaskManagerLocation, ? extends Set<? extends SlotInfo>> slotsPerTaskExecutor) {
+        final Comparator<TaskManagerLocation> taskExecutorComparator =
+                Comparator.comparingInt(tml -> slotsPerTaskExecutor.get(tml).size());
+        return sortTaskExecutors(slotsPerTaskExecutor.keySet(), taskExecutorComparator);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotAssigner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotAssigner.java
@@ -18,18 +18,123 @@
 package org.apache.flink.runtime.scheduler.adaptive.allocator;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.scheduler.adaptive.JobSchedulingPlan.SlotAssignment;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-/** Interface for assigning slots to slot sharing groups. */
+import static java.util.function.Function.identity;
+import static org.apache.flink.runtime.scheduler.adaptive.allocator.SlotSharingSlotAllocator.ExecutionSlotSharingGroup;
+
+/** The Interface for assigning slots to slot sharing groups. */
 @Internal
 public interface SlotAssigner {
+
+    /**
+     * The helper class to represent the allocation score on the specified group and allocated slot.
+     */
+    class AllocationScore implements Comparable<AllocationScore> {
+
+        private final String groupId;
+        private final AllocationID allocationId;
+        private final long score;
+
+        public AllocationScore(String groupId, AllocationID allocationId, long score) {
+            this.groupId = groupId;
+            this.allocationId = allocationId;
+            this.score = score;
+        }
+
+        public String getGroupId() {
+            return groupId;
+        }
+
+        public AllocationID getAllocationId() {
+            return allocationId;
+        }
+
+        public long getScore() {
+            return score;
+        }
+
+        @Override
+        public int compareTo(StateLocalitySlotAssigner.AllocationScore other) {
+            int result = Long.compare(score, other.score);
+            if (result != 0) {
+                return result;
+            }
+            result = other.allocationId.compareTo(allocationId);
+            if (result != 0) {
+                return result;
+            }
+            return other.groupId.compareTo(groupId);
+        }
+    }
 
     Collection<SlotAssignment> assignSlots(
             JobInformation jobInformation,
             Collection<? extends SlotInfo> freeSlots,
             VertexParallelism vertexParallelism,
             JobAllocationsInformation previousAllocations);
+
+    /**
+     * Select the target slots to assign with the requested groups.
+     *
+     * @param slots the raw slots to filter.
+     * @param groups the request execution slot sharing groups.
+     * @param scores the allocation scores.
+     * @return the target slots that are distributed on the minimal task executors.
+     */
+    default Collection<? extends SlotInfo> selectSlotsInMinimalTaskExecutors(
+            Collection<? extends SlotInfo> slots,
+            Collection<ExecutionSlotSharingGroup> groups,
+            Collection<AllocationScore> scores) {
+        if (slots.size() - groups.size() <= 0) {
+            return slots;
+        }
+
+        List<TaskManagerLocation> orderedTaskExecutors =
+                sortPrioritizedTaskExecutors(slots, scores);
+        Map<TaskManagerLocation, ? extends Set<? extends SlotInfo>> slotsByTaskExecutor =
+                SlotAssigner.getSlotsPerTaskExecutor(slots);
+
+        int requestedSlots = groups.size();
+        final List<SlotInfo> result = new ArrayList<>();
+        for (TaskManagerLocation tml : orderedTaskExecutors) {
+            if (requestedSlots <= 0) {
+                break;
+            }
+            final Set<? extends SlotInfo> slotInfos = slotsByTaskExecutor.get(tml);
+            requestedSlots -= slotInfos.size();
+            result.addAll(slotInfos);
+        }
+        return result;
+    }
+
+    /**
+     * Get the task executors with the order that aims to priority assigning requested groups on it.
+     *
+     * @param slots the all slots.
+     * @param scores the allocation scores.
+     * @return the task executors with the order that aims to priority assigning requested groups on
+     *     it.
+     */
+    List<TaskManagerLocation> sortPrioritizedTaskExecutors(
+            Collection<? extends SlotInfo> slots, Collection<AllocationScore> scores);
+
+    static Map<TaskManagerLocation, ? extends Set<? extends SlotInfo>> getSlotsPerTaskExecutor(
+            Collection<? extends SlotInfo> slots) {
+        return slots.stream()
+                .collect(
+                        Collectors.groupingBy(
+                                SlotInfo::getTaskManagerLocation,
+                                Collectors.mapping(identity(), Collectors.toSet())));
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotAssigner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotAssigner.java
@@ -18,13 +18,17 @@
 package org.apache.flink.runtime.scheduler.adaptive.allocator;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.scheduler.adaptive.JobSchedulingPlan.SlotAssignment;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,47 +41,6 @@ import static org.apache.flink.runtime.scheduler.adaptive.allocator.SlotSharingS
 @Internal
 public interface SlotAssigner {
 
-    /**
-     * The helper class to represent the allocation score on the specified group and allocated slot.
-     */
-    class AllocationScore implements Comparable<AllocationScore> {
-
-        private final String groupId;
-        private final AllocationID allocationId;
-        private final long score;
-
-        public AllocationScore(String groupId, AllocationID allocationId, long score) {
-            this.groupId = groupId;
-            this.allocationId = allocationId;
-            this.score = score;
-        }
-
-        public String getGroupId() {
-            return groupId;
-        }
-
-        public AllocationID getAllocationId() {
-            return allocationId;
-        }
-
-        public long getScore() {
-            return score;
-        }
-
-        @Override
-        public int compareTo(StateLocalitySlotAssigner.AllocationScore other) {
-            int result = Long.compare(score, other.score);
-            if (result != 0) {
-                return result;
-            }
-            result = other.allocationId.compareTo(allocationId);
-            if (result != 0) {
-                return result;
-            }
-            return other.groupId.compareTo(groupId);
-        }
-    }
-
     Collection<SlotAssignment> assignSlots(
             JobInformation jobInformation,
             Collection<? extends SlotInfo> freeSlots,
@@ -88,26 +51,22 @@ public interface SlotAssigner {
      * Select the target slots to assign with the requested groups.
      *
      * @param slots the raw slots to filter.
-     * @param groups the request execution slot sharing groups.
-     * @param scores the allocation scores.
+     * @param slotsByTaskExecutor slots per task executor.
+     * @param requestedGroups the number of the request execution slot sharing groups.
      * @return the target slots that are distributed on the minimal task executors.
      */
     default Collection<? extends SlotInfo> selectSlotsInMinimalTaskExecutors(
             Collection<? extends SlotInfo> slots,
-            Collection<ExecutionSlotSharingGroup> groups,
-            Collection<AllocationScore> scores) {
-        if (slots.size() - groups.size() <= 0) {
+            Map<TaskManagerLocation, ? extends Set<? extends SlotInfo>> slotsByTaskExecutor,
+            int requestedGroups,
+            List<TaskManagerLocation> sortedTaskExecutors) {
+        if (slots.size() - requestedGroups <= 0) {
             return slots;
         }
 
-        List<TaskManagerLocation> orderedTaskExecutors =
-                sortPrioritizedTaskExecutors(slots, scores);
-        Map<TaskManagerLocation, ? extends Set<? extends SlotInfo>> slotsByTaskExecutor =
-                SlotAssigner.getSlotsPerTaskExecutor(slots);
-
-        int requestedSlots = groups.size();
+        int requestedSlots = requestedGroups;
         final List<SlotInfo> result = new ArrayList<>();
-        for (TaskManagerLocation tml : orderedTaskExecutors) {
+        for (TaskManagerLocation tml : sortedTaskExecutors) {
             if (requestedSlots <= 0) {
                 break;
             }
@@ -121,13 +80,17 @@ public interface SlotAssigner {
     /**
      * Get the task executors with the order that aims to priority assigning requested groups on it.
      *
-     * @param slots the all slots.
-     * @param scores the allocation scores.
-     * @return the task executors with the order that aims to priority assigning requested groups on
-     *     it.
+     * @param taskManagerLocations task executors to sort.
+     * @param taskExecutorComparator the comparator to compare the target task executors.
+     * @return The sorted task executors list with the specified order by the comparator.
      */
-    List<TaskManagerLocation> sortPrioritizedTaskExecutors(
-            Collection<? extends SlotInfo> slots, Collection<AllocationScore> scores);
+    static List<TaskManagerLocation> sortTaskExecutors(
+            Collection<TaskManagerLocation> taskManagerLocations,
+            Comparator<TaskManagerLocation> taskExecutorComparator) {
+        return taskManagerLocations.stream()
+                .sorted(taskExecutorComparator)
+                .collect(Collectors.toList());
+    }
 
     static Map<TaskManagerLocation, ? extends Set<? extends SlotInfo>> getSlotsPerTaskExecutor(
             Collection<? extends SlotInfo> slots) {
@@ -136,5 +99,24 @@ public interface SlotAssigner {
                         Collectors.groupingBy(
                                 SlotInfo::getTaskManagerLocation,
                                 Collectors.mapping(identity(), Collectors.toSet())));
+    }
+
+    static List<ExecutionSlotSharingGroup> createExecutionSlotSharingGroups(
+            VertexParallelism vertexParallelism, SlotSharingGroup slotSharingGroup) {
+        final Map<Integer, Set<ExecutionVertexID>> sharedSlotToVertexAssignment = new HashMap<>();
+        slotSharingGroup
+                .getJobVertexIds()
+                .forEach(
+                        jobVertexId -> {
+                            int parallelism = vertexParallelism.getParallelism(jobVertexId);
+                            for (int subtaskIdx = 0; subtaskIdx < parallelism; subtaskIdx++) {
+                                sharedSlotToVertexAssignment
+                                        .computeIfAbsent(subtaskIdx, ignored -> new HashSet<>())
+                                        .add(new ExecutionVertexID(jobVertexId, subtaskIdx));
+                            }
+                        });
+        return sharedSlotToVertexAssignment.values().stream()
+                .map(SlotSharingSlotAllocator.ExecutionSlotSharingGroup::new)
+                .collect(Collectors.toList());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateLocalitySlotAssigner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateLocalitySlotAssigner.java
@@ -18,6 +18,7 @@
 package org.apache.flink.runtime.scheduler.adaptive.allocator;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
@@ -46,12 +47,53 @@ import java.util.stream.Collectors;
 
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
-import static org.apache.flink.runtime.scheduler.adaptive.allocator.DefaultSlotAssigner.createExecutionSlotSharingGroups;
+import static org.apache.flink.runtime.scheduler.adaptive.allocator.SlotAssigner.createExecutionSlotSharingGroups;
+import static org.apache.flink.runtime.scheduler.adaptive.allocator.SlotAssigner.getSlotsPerTaskExecutor;
+import static org.apache.flink.runtime.scheduler.adaptive.allocator.SlotAssigner.sortTaskExecutors;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /** A {@link SlotAssigner} that assigns slots based on the number of local key groups. */
 @Internal
 public class StateLocalitySlotAssigner implements SlotAssigner {
+
+    @VisibleForTesting
+    static class AllocationScore implements Comparable<AllocationScore> {
+
+        private final String groupId;
+        private final AllocationID allocationId;
+        private final long score;
+
+        public AllocationScore(String groupId, AllocationID allocationId, long score) {
+            this.groupId = groupId;
+            this.allocationId = allocationId;
+            this.score = score;
+        }
+
+        public String getGroupId() {
+            return groupId;
+        }
+
+        public AllocationID getAllocationId() {
+            return allocationId;
+        }
+
+        public long getScore() {
+            return score;
+        }
+
+        @Override
+        public int compareTo(StateLocalitySlotAssigner.AllocationScore other) {
+            int result = Long.compare(score, other.score);
+            if (result != 0) {
+                return result;
+            }
+            result = other.allocationId.compareTo(allocationId);
+            if (result != 0) {
+                return result;
+            }
+            return other.groupId.compareTo(groupId);
+        }
+    }
 
     @Override
     public Collection<SlotAssignment> assignSlots(
@@ -75,9 +117,18 @@ public class StateLocalitySlotAssigner implements SlotAssigner {
 
         final Map<String, ExecutionSlotSharingGroup> groupsById =
                 allGroups.stream().collect(toMap(ExecutionSlotSharingGroup::getId, identity()));
+
+        final Map<TaskManagerLocation, ? extends Set<? extends SlotInfo>> slotsPerTaskExecutor =
+                getSlotsPerTaskExecutor(freeSlots);
+        final Collection<? extends SlotInfo> slotInfos =
+                selectSlotsInMinimalTaskExecutors(
+                        freeSlots,
+                        slotsPerTaskExecutor,
+                        allGroups.size(),
+                        getSortedTaskExecutors(freeSlots, slotsPerTaskExecutor, scores));
+
         final Map<AllocationID, SlotInfo> slotsById =
-                selectSlotsInMinimalTaskExecutors(freeSlots, allGroups, scores).stream()
-                        .collect(toMap(SlotInfo::getAllocationId, identity()));
+                slotInfos.stream().collect(toMap(SlotInfo::getAllocationId, identity()));
         AllocationScore score;
         final Collection<SlotAssignment> assignments = new ArrayList<>();
         while ((score = scores.poll()) != null) {
@@ -104,34 +155,27 @@ public class StateLocalitySlotAssigner implements SlotAssigner {
         return assignments;
     }
 
-    @Override
-    public List<TaskManagerLocation> sortPrioritizedTaskExecutors(
-            Collection<? extends SlotInfo> slots, Collection<AllocationScore> scores) {
-        Map<TaskManagerLocation, ? extends Set<? extends SlotInfo>> slotsByTaskExecutor =
-                SlotAssigner.getSlotsPerTaskExecutor(slots);
-        final Map<AllocationID, TaskManagerLocation> allocIdToTaskExecutor =
-                slots.stream()
-                        .collect(
-                                Collectors.toMap(
-                                        SlotInfo::getAllocationId,
-                                        SlotInfo::getTaskManagerLocation));
+    @VisibleForTesting
+    List<TaskManagerLocation> getSortedTaskExecutors(
+            Collection<? extends SlotInfo> freeSlots,
+            Map<TaskManagerLocation, ? extends Set<? extends SlotInfo>> slotsPerTaskExecutor,
+            PriorityQueue<AllocationScore> scores) {
+        final Map<TaskManagerLocation, Long> scorePerTaskExecutor =
+                getScorePerTaskExecutor(freeSlots, slotsPerTaskExecutor, scores);
+        final Comparator<TaskManagerLocation> taskExecutorComparator =
+                (left, right) -> {
+                    int diff =
+                            Integer.compare(
+                                    slotsPerTaskExecutor.get(left).size(),
+                                    slotsPerTaskExecutor.get(right).size());
+                    return diff != 0
+                            ? diff
+                            : Long.compare(
+                                    scorePerTaskExecutor.getOrDefault(right, 0L),
+                                    scorePerTaskExecutor.getOrDefault(left, 0L));
+                };
 
-        Map<TaskManagerLocation, Long> scorePerTaskExecutor =
-                getScorePerTaskExecutor(scores, slotsByTaskExecutor, allocIdToTaskExecutor);
-        return slotsByTaskExecutor.keySet().stream()
-                .sorted(
-                        (left, right) -> {
-                            int diff =
-                                    Integer.compare(
-                                            slotsByTaskExecutor.get(right).size(),
-                                            slotsByTaskExecutor.get(left).size());
-                            return diff != 0
-                                    ? diff
-                                    : Long.compare(
-                                            scorePerTaskExecutor.getOrDefault(right, 0L),
-                                            scorePerTaskExecutor.getOrDefault(left, 0L));
-                        })
-                .collect(Collectors.toList());
+        return sortTaskExecutors(slotsPerTaskExecutor.keySet(), taskExecutorComparator);
     }
 
     @Nonnull
@@ -206,10 +250,16 @@ public class StateLocalitySlotAssigner implements SlotAssigner {
     }
 
     private static Map<TaskManagerLocation, Long> getScorePerTaskExecutor(
-            Collection<AllocationScore> scores,
+            Collection<? extends SlotInfo> slots,
             Map<TaskManagerLocation, ? extends Set<? extends SlotInfo>> slotsByTaskExecutor,
-            Map<AllocationID, TaskManagerLocation> allocIdToTaskExecutor) {
-        Map<TaskManagerLocation, Long> scorePerTaskExecutor =
+            Collection<AllocationScore> scores) {
+        final Map<AllocationID, TaskManagerLocation> allocIdToTaskExecutor =
+                slots.stream()
+                        .collect(
+                                Collectors.toMap(
+                                        SlotInfo::getAllocationId,
+                                        SlotInfo::getTaskManagerLocation));
+        final Map<TaskManagerLocation, Long> scorePerTaskExecutor =
                 new HashMap<>(slotsByTaskExecutor.size());
         for (AllocationScore allocScore : scores) {
             final TaskManagerLocation tml = allocIdToTaskExecutor.get(allocScore.getAllocationId());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotAssignerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotAssignerTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive.allocator;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.runtime.scheduler.adaptive.allocator.SlotAssigner.AllocationScore;
+import static org.apache.flink.runtime.scheduler.adaptive.allocator.SlotSharingSlotAllocator.ExecutionSlotSharingGroup;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link SlotAssigner}. */
+class SlotAssignerTest {
+
+    private static final TaskManagerLocation tml1 = new LocalTaskManagerLocation();
+    private static final AllocationID allocationId1OfTml1 = new AllocationID();
+    private static final AllocationID allocationId2OfTml1 = new AllocationID();
+    private static final AllocationID allocationId3OfTml1 = new AllocationID();
+    private static final List<TestingSlot> slotsOfTml1 =
+            createSlots(tml1, allocationId1OfTml1, allocationId2OfTml1, allocationId3OfTml1);
+
+    private static final TaskManagerLocation tml2 = new LocalTaskManagerLocation();
+    private static final AllocationID allocationId1OfTml2 = new AllocationID();
+    private static final AllocationID allocationId2OfTml2 = new AllocationID();
+    private static final List<TestingSlot> slotsOfTml2 =
+            createSlots(tml2, allocationId1OfTml2, allocationId2OfTml2);
+
+    private static final TaskManagerLocation tml3 = new LocalTaskManagerLocation();
+    private static final AllocationID allocationId1OfTml3 = new AllocationID();
+    private static final AllocationID allocationId2OfTml3 = new AllocationID();
+    private static final List<TestingSlot> slotsOfTml3 =
+            createSlots(tml3, allocationId1OfTml3, allocationId2OfTml3);
+
+    /** Helper class. */
+    private static class AllocationIdScore {
+        AllocationID allocationID;
+        long score;
+
+        public AllocationIdScore(AllocationID allocationID, long score) {
+            this.allocationID = allocationID;
+            this.score = score;
+        }
+
+        @Override
+        public String toString() {
+            return "AllocationIdScore{" + "allocationID=" + allocationID + ", score=" + score + '}';
+        }
+    }
+
+    private static Stream<Arguments> getTestingParameters() {
+        return Stream.of(
+                Arguments.of(
+                        new StateLocalitySlotAssigner(),
+                        5,
+                        Arrays.asList(
+                                new AllocationIdScore(allocationId1OfTml2, 2),
+                                new AllocationIdScore(allocationId1OfTml3, 1)),
+                        Arrays.asList(tml1, tml2)),
+                Arguments.of(
+                        new StateLocalitySlotAssigner(),
+                        5,
+                        Arrays.asList(
+                                new AllocationIdScore(allocationId1OfTml3, 2),
+                                new AllocationIdScore(allocationId1OfTml3, 1)),
+                        Arrays.asList(tml1, tml3)),
+                Arguments.of(
+                        new StateLocalitySlotAssigner(),
+                        3,
+                        Collections.emptyList(),
+                        Collections.singletonList(tml1)),
+                Arguments.of(
+                        new StateLocalitySlotAssigner(),
+                        6,
+                        Collections.singletonList(new AllocationIdScore(allocationId1OfTml2, 2)),
+                        Arrays.asList(tml1, tml2, tml3)),
+                Arguments.of(
+                        new StateLocalitySlotAssigner(),
+                        6,
+                        Collections.emptyList(),
+                        Arrays.asList(tml1, tml2, tml3)),
+                Arguments.of(
+                        new DefaultSlotAssigner(),
+                        3,
+                        Collections.emptyList(),
+                        Collections.singletonList(tml1)),
+                Arguments.of(
+                        new DefaultSlotAssigner(),
+                        2,
+                        Collections.singletonList(new AllocationIdScore(allocationId1OfTml2, 2)),
+                        Collections.singletonList(tml1)));
+    }
+
+    @MethodSource("getTestingParameters")
+    @ParameterizedTest(
+            name = "slotAssigner={0}, group={1}, scoredAllocations={2}, minimalTaskExecutors={3}")
+    void testSelectSlotsInMinimalTaskExecutors(
+            SlotAssigner slotAssigner,
+            int groups,
+            List<AllocationIdScore> scoredAllocations,
+            List<TaskManagerLocation> minimalTaskExecutors) {
+        List<TestingSlot> slots = new ArrayList<>();
+        slots.addAll(slotsOfTml1);
+        slots.addAll(slotsOfTml2);
+        slots.addAll(slotsOfTml3);
+
+        final List<ExecutionSlotSharingGroup> groupsPlaceholders = createGroups(groups);
+        Collection<AllocationScore> scores = getAllocationScores(scoredAllocations);
+        Set<TaskManagerLocation> keptTaskExecutors =
+                slotAssigner.selectSlotsInMinimalTaskExecutors(slots, groupsPlaceholders, scores)
+                        .stream()
+                        .map(SlotInfo::getTaskManagerLocation)
+                        .collect(Collectors.toSet());
+        assertThat(minimalTaskExecutors).containsAll(keptTaskExecutors);
+    }
+
+    private static Collection<AllocationScore> getAllocationScores(
+            List<AllocationIdScore> scoredAllocations) {
+        if (scoredAllocations == null) {
+            return new ArrayList<>();
+        }
+        return scoredAllocations.stream()
+                .map(
+                        allocationIdScore ->
+                                new AllocationScore(
+                                        UUID.randomUUID().toString(),
+                                        allocationIdScore.allocationID,
+                                        allocationIdScore.score))
+                .collect(Collectors.toList());
+    }
+
+    private static List<TestingSlot> createSlots(
+            TaskManagerLocation tmLocation, AllocationID... allocationIDs) {
+        final List<TestingSlot> result = new ArrayList<>(allocationIDs.length);
+        for (AllocationID allocationID : allocationIDs) {
+            result.add(new TestingSlot(allocationID, ResourceProfile.ANY, tmLocation));
+        }
+        return result;
+    }
+
+    private static List<ExecutionSlotSharingGroup> createGroups(int num) {
+        final List<ExecutionSlotSharingGroup> result = new ArrayList<>(num);
+        for (int i = 0; i < num; i++) {
+            result.add(new ExecutionSlotSharingGroup(Collections.emptySet()));
+        }
+        return result;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotAssignerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotAssignerTest.java
@@ -17,8 +17,7 @@
 
 package org.apache.flink.runtime.scheduler.adaptive.allocator;
 
-import org.apache.flink.runtime.clusterframework.types.AllocationID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
@@ -27,153 +26,144 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.flink.runtime.scheduler.adaptive.allocator.SlotAssigner.AllocationScore;
-import static org.apache.flink.runtime.scheduler.adaptive.allocator.SlotSharingSlotAllocator.ExecutionSlotSharingGroup;
+import static org.apache.flink.runtime.scheduler.adaptive.allocator.SlotAssigner.getSlotsPerTaskExecutor;
+import static org.apache.flink.runtime.scheduler.adaptive.allocator.StateLocalitySlotAssigner.AllocationScore;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link SlotAssigner}. */
 class SlotAssignerTest {
 
     private static final TaskManagerLocation tml1 = new LocalTaskManagerLocation();
-    private static final AllocationID allocationId1OfTml1 = new AllocationID();
-    private static final AllocationID allocationId2OfTml1 = new AllocationID();
-    private static final AllocationID allocationId3OfTml1 = new AllocationID();
-    private static final List<TestingSlot> slotsOfTml1 =
-            createSlots(tml1, allocationId1OfTml1, allocationId2OfTml1, allocationId3OfTml1);
+    private static final SlotInfo slot1OfTml1 = new TestingSlot(tml1);
+    private static final SlotInfo slot2OfTml1 = new TestingSlot(tml1);
+    private static final SlotInfo slot3OfTml1 = new TestingSlot(tml1);
 
     private static final TaskManagerLocation tml2 = new LocalTaskManagerLocation();
-    private static final AllocationID allocationId1OfTml2 = new AllocationID();
-    private static final AllocationID allocationId2OfTml2 = new AllocationID();
-    private static final List<TestingSlot> slotsOfTml2 =
-            createSlots(tml2, allocationId1OfTml2, allocationId2OfTml2);
+    private static final SlotInfo slot1OfTml2 = new TestingSlot(tml2);
+    private static final SlotInfo slot2OfTml2 = new TestingSlot(tml2);
+    private static final SlotInfo slot3OfTml2 = new TestingSlot(tml2);
 
     private static final TaskManagerLocation tml3 = new LocalTaskManagerLocation();
-    private static final AllocationID allocationId1OfTml3 = new AllocationID();
-    private static final AllocationID allocationId2OfTml3 = new AllocationID();
-    private static final List<TestingSlot> slotsOfTml3 =
-            createSlots(tml3, allocationId1OfTml3, allocationId2OfTml3);
+    private static final SlotInfo slot1OfTml3 = new TestingSlot(tml3);
+    private static final SlotInfo slot2OfTml3 = new TestingSlot(tml3);
 
-    /** Helper class. */
-    private static class AllocationIdScore {
-        AllocationID allocationID;
-        long score;
-
-        public AllocationIdScore(AllocationID allocationID, long score) {
-            this.allocationID = allocationID;
-            this.score = score;
-        }
-
-        @Override
-        public String toString() {
-            return "AllocationIdScore{" + "allocationID=" + allocationID + ", score=" + score + '}';
-        }
-    }
+    private static final List<SlotInfo> allSlots =
+            Arrays.asList(
+                    slot1OfTml1,
+                    slot2OfTml1,
+                    slot3OfTml1,
+                    slot1OfTml2,
+                    slot2OfTml2,
+                    slot3OfTml2,
+                    slot1OfTml3,
+                    slot2OfTml3);
 
     private static Stream<Arguments> getTestingParameters() {
         return Stream.of(
                 Arguments.of(
                         new StateLocalitySlotAssigner(),
-                        5,
-                        Arrays.asList(
-                                new AllocationIdScore(allocationId1OfTml2, 2),
-                                new AllocationIdScore(allocationId1OfTml3, 1)),
-                        Arrays.asList(tml1, tml2)),
-                Arguments.of(
-                        new StateLocalitySlotAssigner(),
-                        5,
-                        Arrays.asList(
-                                new AllocationIdScore(allocationId1OfTml3, 2),
-                                new AllocationIdScore(allocationId1OfTml3, 1)),
+                        3,
+                        allSlots,
+                        createTestingScores(Tuple2.of(slot1OfTml1, 2L), Tuple2.of(slot1OfTml2, 1L)),
                         Arrays.asList(tml1, tml3)),
                 Arguments.of(
                         new StateLocalitySlotAssigner(),
-                        3,
-                        Collections.emptyList(),
-                        Collections.singletonList(tml1)),
+                        2,
+                        allSlots,
+                        createTestingScores(Tuple2.of(slot1OfTml1, 2L), Tuple2.of(slot1OfTml2, 2L)),
+                        Collections.singletonList(tml3)),
                 Arguments.of(
                         new StateLocalitySlotAssigner(),
                         6,
-                        Collections.singletonList(new AllocationIdScore(allocationId1OfTml2, 2)),
+                        allSlots,
+                        createTestingScores(Tuple2.of(slot1OfTml2, 2L)),
                         Arrays.asList(tml1, tml2, tml3)),
                 Arguments.of(
                         new StateLocalitySlotAssigner(),
-                        6,
-                        Collections.emptyList(),
-                        Arrays.asList(tml1, tml2, tml3)),
-                Arguments.of(
-                        new DefaultSlotAssigner(),
-                        3,
-                        Collections.emptyList(),
-                        Collections.singletonList(tml1)),
+                        4,
+                        Arrays.asList(
+                                slot1OfTml1,
+                                slot2OfTml1,
+                                slot1OfTml2,
+                                slot2OfTml2,
+                                slot1OfTml3,
+                                slot2OfTml3),
+                        createTestingScores(Tuple2.of(slot1OfTml2, 2L), Tuple2.of(slot2OfTml3, 1L)),
+                        Arrays.asList(tml2, tml3)),
                 Arguments.of(
                         new DefaultSlotAssigner(),
                         2,
-                        Collections.singletonList(new AllocationIdScore(allocationId1OfTml2, 2)),
-                        Collections.singletonList(tml1)));
+                        allSlots,
+                        null,
+                        Collections.singletonList(tml3)),
+                Arguments.of(
+                        new DefaultSlotAssigner(),
+                        3,
+                        Arrays.asList(slot1OfTml1, slot1OfTml2, slot2OfTml2, slot3OfTml2),
+                        null,
+                        Arrays.asList(tml1, tml2)),
+                Arguments.of(
+                        new DefaultSlotAssigner(),
+                        7,
+                        allSlots,
+                        createTestingScores(Tuple2.of(slot1OfTml2, 2L)),
+                        Arrays.asList(tml1, tml2, tml3)));
     }
 
     @MethodSource("getTestingParameters")
     @ParameterizedTest(
-            name = "slotAssigner={0}, group={1}, scoredAllocations={2}, minimalTaskExecutors={3}")
+            name =
+                    "slotAssigner={0}, groups={1}, allSlots={2}, scoredAllocations={3}, minimalTaskExecutors={4}")
     void testSelectSlotsInMinimalTaskExecutors(
             SlotAssigner slotAssigner,
-            int groups,
-            List<AllocationIdScore> scoredAllocations,
+            int requestGroups,
+            List<SlotInfo> allSlots,
+            PriorityQueue<AllocationScore> scores,
             List<TaskManagerLocation> minimalTaskExecutors) {
-        List<TestingSlot> slots = new ArrayList<>();
-        slots.addAll(slotsOfTml1);
-        slots.addAll(slotsOfTml2);
-        slots.addAll(slotsOfTml3);
+        Map<TaskManagerLocation, ? extends Set<? extends SlotInfo>> slotsPerTaskExecutor =
+                getSlotsPerTaskExecutor(allSlots);
+        List<TaskManagerLocation> sortedTaskExecutors;
+        if (slotAssigner instanceof StateLocalitySlotAssigner) {
+            sortedTaskExecutors =
+                    ((StateLocalitySlotAssigner) slotAssigner)
+                            .getSortedTaskExecutors(allSlots, slotsPerTaskExecutor, scores);
+        } else if (slotAssigner instanceof DefaultSlotAssigner) {
+            sortedTaskExecutors =
+                    ((DefaultSlotAssigner) slotAssigner)
+                            .getSortedTaskExecutors(slotsPerTaskExecutor);
+        } else {
+            throw new IllegalStateException(
+                    "Unexpected implementations of " + SlotAssigner.class.getName());
+        }
 
-        final List<ExecutionSlotSharingGroup> groupsPlaceholders = createGroups(groups);
-        Collection<AllocationScore> scores = getAllocationScores(scoredAllocations);
         Set<TaskManagerLocation> keptTaskExecutors =
-                slotAssigner.selectSlotsInMinimalTaskExecutors(slots, groupsPlaceholders, scores)
+                slotAssigner
+                        .selectSlotsInMinimalTaskExecutors(
+                                allSlots, slotsPerTaskExecutor, requestGroups, sortedTaskExecutors)
                         .stream()
                         .map(SlotInfo::getTaskManagerLocation)
                         .collect(Collectors.toSet());
         assertThat(minimalTaskExecutors).containsAll(keptTaskExecutors);
     }
 
-    private static Collection<AllocationScore> getAllocationScores(
-            List<AllocationIdScore> scoredAllocations) {
-        if (scoredAllocations == null) {
-            return new ArrayList<>();
-        }
-        return scoredAllocations.stream()
-                .map(
-                        allocationIdScore ->
-                                new AllocationScore(
-                                        UUID.randomUUID().toString(),
-                                        allocationIdScore.allocationID,
-                                        allocationIdScore.score))
-                .collect(Collectors.toList());
-    }
-
-    private static List<TestingSlot> createSlots(
-            TaskManagerLocation tmLocation, AllocationID... allocationIDs) {
-        final List<TestingSlot> result = new ArrayList<>(allocationIDs.length);
-        for (AllocationID allocationID : allocationIDs) {
-            result.add(new TestingSlot(allocationID, ResourceProfile.ANY, tmLocation));
-        }
-        return result;
-    }
-
-    private static List<ExecutionSlotSharingGroup> createGroups(int num) {
-        final List<ExecutionSlotSharingGroup> result = new ArrayList<>(num);
-        for (int i = 0; i < num; i++) {
-            result.add(new ExecutionSlotSharingGroup(Collections.emptySet()));
-        }
-        return result;
+    @SafeVarargs
+    private static PriorityQueue<AllocationScore> createTestingScores(
+            Tuple2<SlotInfo, Long>... scorePairs) {
+        final PriorityQueue<AllocationScore> scores =
+                new PriorityQueue<>(Comparator.reverseOrder());
+        Arrays.stream(scorePairs)
+                .map(t2 -> new AllocationScore("unUsedGid", t2.f0.getAllocationId(), t2.f1))
+                .forEach(scores::add);
+        return scores;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/TestingSlot.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/TestingSlot.java
@@ -44,9 +44,16 @@ public class TestingSlot implements PhysicalSlot {
     }
 
     public TestingSlot(AllocationID allocationId, ResourceProfile resourceProfile) {
+        this(allocationId, resourceProfile, new LocalTaskManagerLocation());
+    }
+
+    public TestingSlot(
+            AllocationID allocationId,
+            ResourceProfile resourceProfile,
+            TaskManagerLocation taskManagerLocation) {
         this.allocationId = allocationId;
         this.resourceProfile = resourceProfile;
-        this.taskManagerLocation = new LocalTaskManagerLocation();
+        this.taskManagerLocation = taskManagerLocation;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/TestingSlot.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/TestingSlot.java
@@ -29,6 +29,7 @@ public class TestingSlot implements PhysicalSlot {
 
     private final AllocationID allocationId;
     private final ResourceProfile resourceProfile;
+    private final TaskManagerLocation taskManagerLocation;
 
     public TestingSlot() {
         this(new AllocationID(), ResourceProfile.ANY);
@@ -45,6 +46,7 @@ public class TestingSlot implements PhysicalSlot {
     public TestingSlot(AllocationID allocationId, ResourceProfile resourceProfile) {
         this.allocationId = allocationId;
         this.resourceProfile = resourceProfile;
+        this.taskManagerLocation = new LocalTaskManagerLocation();
     }
 
     @Override
@@ -54,7 +56,7 @@ public class TestingSlot implements PhysicalSlot {
 
     @Override
     public TaskManagerLocation getTaskManagerLocation() {
-        return new LocalTaskManagerLocation();
+        return taskManagerLocation;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/TestingSlot.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/TestingSlot.java
@@ -43,6 +43,10 @@ public class TestingSlot implements PhysicalSlot {
         this(new AllocationID(), resourceProfile);
     }
 
+    public TestingSlot(TaskManagerLocation tml) {
+        this(new AllocationID(), ResourceProfile.ANY, tml);
+    }
+
     public TestingSlot(AllocationID allocationId, ResourceProfile resourceProfile) {
         this(allocationId, resourceProfile, new LocalTaskManagerLocation());
     }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

## Summary by Sourcery

Extract common slot selection and executor-sorting functionality into the SlotAssigner interface, update both StateLocalitySlotAssigner and DefaultSlotAssigner to use this shared logic for minimal TaskManager utilization, adjust TestingSlot to carry TaskManagerLocation, and add comprehensive unit tests for the new selection behavior.

Enhancements:
- Extract common slot grouping, sorting, and minimal-executor selection logic into the SlotAssigner interface
- Refactor StateLocalitySlotAssigner and DefaultSlotAssigner to leverage the new slot selection and executor sorting utilities
- Expose and annotate getSortedTaskExecutors methods for both assigners to support testing
- Enhance TestingSlot to retain and return a TaskManagerLocation for accurate executor mapping

Tests:
- Introduce SlotAssignerTest with parameterized scenarios to validate minimal TaskManager selection